### PR TITLE
Status history updates

### DIFF
--- a/.github/workflows/update-status-history.yml
+++ b/.github/workflows/update-status-history.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: scripts
       - run: |
           node lib/actions/update-status-history.js \
-            --dryRun "true" \
+            --dryRun "false" \
             --org "${{ matrix.owner }}" \
             --projectNumber "${{ matrix.project_number }}"
         working-directory: scripts

--- a/.github/workflows/update-status-history.yml
+++ b/.github/workflows/update-status-history.yml
@@ -13,17 +13,22 @@ jobs:
       matrix:
         include:
           - owner: pl-strflt
-            project_name: InterPlanetary Developer Experience
-          - owner: ipfs
-            project_name: Kubo IPFS Stewards (PL EngRes)
-          - owner: libp2p
-            project_name: Go libp2p Stewards (PL EngRes)
-          - owner: ipld
-            project_name: "IPLD team's weekly tracker"
+            project_number: 1
+          # - owner: ipfs
+          #   project_number: Kubo IPFS Stewards (PL EngRes)
+          # - owner: libp2p
+          #   project_number: Go libp2p Stewards (PL EngRes)
+          # - owner: ipld
+          #   project_number: "IPLD team's weekly tracker"
     env:
       GITHUB_TOKEN: ${{ secrets.GALARGH_GITHUB_TOKEN }}
     steps:
-      - uses: pl-strflt/projects-status-history@main
-        with:
-          owner: ${{ matrix.owner }}
-          project_name: ${{ matrix.project_name }}
+      - uses: actions/checkout@v3
+      - run: npm install && npm run build
+        working-directory: scripts
+      - run: |
+          node lib/actions/update-status-history.js \
+            --dryRun "true" \
+            --org "${{ matrix.owner }}" \
+            --projectNumber "${{ matrix.project_number }}"
+        working-directory: scripts

--- a/.github/workflows/update-status-history.yml
+++ b/.github/workflows/update-status-history.yml
@@ -14,12 +14,12 @@ jobs:
         include:
           - owner: pl-strflt
             project_number: 1
-          # - owner: ipfs
-          #   project_number: Kubo IPFS Stewards (PL EngRes)
-          # - owner: libp2p
-          #   project_number: Go libp2p Stewards (PL EngRes)
-          # - owner: ipld
-          #   project_number: "IPLD team's weekly tracker"
+          - owner: ipfs
+            project_number: 16
+          - owner: libp2p
+            project_number: 3
+          - owner: ipld
+            project_number: 3
     env:
       GITHUB_TOKEN: ${{ secrets.GALARGH_GITHUB_TOKEN }}
     steps:

--- a/scripts/src/actions/shared/update-status-history.ts
+++ b/scripts/src/actions/shared/update-status-history.ts
@@ -3,7 +3,12 @@ import * as core from '@actions/core'
 import assert from 'assert'
 import { GraphQlResponse } from '@octokit/graphql/dist-types/types'
 
-async function updateProjectV2ItemFieldValue(projectId: string, itemId: string, fieldId: string, value: string): GraphQlResponse<unknown> {
+async function updateProjectV2ItemFieldValue(
+  projectId: string,
+  itemId: string,
+  fieldId: string,
+  value: string
+): GraphQlResponse<unknown> {
   const github = await GitHub.getGitHub()
   return github.client.graphql(
     `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
@@ -86,25 +91,47 @@ export async function updateStatusHistory(
   core.info(`Found project: ${project.id}`)
 
   core.info(`Checking if required fields exist`)
-  const statusField = project.fields.nodes.find((field: any) => field.name === 'Status')
+  const statusField = project.fields.nodes.find(
+    (field: any) => field.name === 'Status'
+  )
   assert(statusField, `Project must have a field named 'Status'`)
-  const statusDateField = project.fields.nodes.find((field: any) => field.name === 'Status Date')
+  const statusDateField = project.fields.nodes.find(
+    (field: any) => field.name === 'Status Date'
+  )
   assert(statusDateField, `Project must have a field named 'Status Date'`)
-  const statusHistoryField = project.fields.nodes.find((field: any) => field.name === 'Status History')
+  const statusHistoryField = project.fields.nodes.find(
+    (field: any) => field.name === 'Status History'
+  )
   assert(statusHistoryField, `Project must have a field named 'Status History'`)
-  const statusTimestampField = project.fields.nodes.find((field: any) => field.name === 'Status Timestamp')
-  assert(statusTimestampField, `Project must have a field named 'Status Timestamp'`)
+  const statusTimestampField = project.fields.nodes.find(
+    (field: any) => field.name === 'Status Timestamp'
+  )
+  assert(
+    statusTimestampField,
+    `Project must have a field named 'Status Timestamp'`
+  )
   core.info(`Found all required fields`)
 
   core.info(`Updating status history for all items`)
   for (const item of project.items.nodes) {
     if (item.title === "You can't see this item") {
-      core.warning(`The following item is inaccessible: ${JSON.stringify(item)}`)
+      core.warning(
+        `The following item is inaccessible: ${JSON.stringify(item)}`
+      )
       continue
     }
-    core.debug(`Checking if item needs to be updated: ${item.id} (${item.title})`)
-    const status = item.fieldValues.nodes.find((field: any) => field.projectField.id === statusField.id)?.value
-    const statusHistory = JSON.parse(item.fieldValues.nodes.find((fieldValue: any) => fieldValue.projectField.id === statusHistoryField.id)?.value || '[]')
+    core.debug(
+      `Checking if item needs to be updated: ${item.id} (${item.title})`
+    )
+    const status = item.fieldValues.nodes.find(
+      (field: any) => field.projectField.id === statusField.id
+    )?.value
+    const statusHistory = JSON.parse(
+      item.fieldValues.nodes.find(
+        (fieldValue: any) =>
+          fieldValue.projectField.id === statusHistoryField.id
+      )?.value || '[]'
+    )
     if (status === statusHistory.at(0)) {
       core.debug(`Item is up to date: ${item.id} (${item.title})`)
       continue
@@ -115,11 +142,25 @@ export async function updateStatusHistory(
     }
     core.info(`Updating item: ${item.id} (${item.title})`)
     const newStatusHistory = [status.value, ...statusHistory.slice(0, 1)]
-    await updateProjectV2ItemFieldValue(project.id, item.id, statusHistoryField.id, JSON.stringify(newStatusHistory))
-    await updateProjectV2ItemFieldValue(project.id, item.id, statusTimestampField.id, timestamp)
-    await updateProjectV2ItemFieldValue(project.id, item.id, statusDateField.id, simpleDate)
+    await updateProjectV2ItemFieldValue(
+      project.id,
+      item.id,
+      statusHistoryField.id,
+      JSON.stringify(newStatusHistory)
+    )
+    await updateProjectV2ItemFieldValue(
+      project.id,
+      item.id,
+      statusTimestampField.id,
+      timestamp
+    )
+    await updateProjectV2ItemFieldValue(
+      project.id,
+      item.id,
+      statusDateField.id,
+      simpleDate
+    )
     core.info(`Updated item: ${item.id} (${item.title})`)
-
   }
   core.info(`Done`)
 }

--- a/scripts/src/actions/shared/update-status-history.ts
+++ b/scripts/src/actions/shared/update-status-history.ts
@@ -7,19 +7,17 @@ async function updateProjectV2ItemFieldValue(
   projectId: string,
   itemId: string,
   fieldId: string,
-  value: string
+  value: any
 ): GraphQlResponse<unknown> {
   const github = await GitHub.getGitHub()
   return github.client.graphql(
-    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
       updateProjectV2ItemFieldValue(
         input: {
           projectId: $projectId
           itemId: $itemId
           fieldId: $fieldId
-          value: {
-            text: $value
-          }
+          value: $value
         }
       ) {
         projectV2Item {
@@ -42,8 +40,8 @@ export async function updateStatusHistory(
   dryRun: boolean
 ) {
   const date = new Date()
-  const timestamp = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()} ${date.getUTCHours()}:${date.getUTCMinutes()}`
-  const simpleDate = `${date.getUTCDate()}/${date.getUTCMonth()}/${date.getUTCFullYear()}`
+  const datetime = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()} ${date.getUTCHours()}:${date.getUTCMinutes()}`
+  const dateonly = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`
   const github = await GitHub.getGitHub()
 
   core.info(`Searching for project: ${org}/${projectNumber}`)
@@ -163,19 +161,25 @@ export async function updateStatusHistory(
       project.id,
       item.id,
       statusHistoryField.id,
-      JSON.stringify(newStatusHistory)
+      {
+        text: JSON.stringify(newStatusHistory)
+      }
     )
     await updateProjectV2ItemFieldValue(
       project.id,
       item.id,
       statusTimestampField.id,
-      timestamp
+      {
+        text: datetime
+      }
     )
     await updateProjectV2ItemFieldValue(
       project.id,
       item.id,
       statusDateField.id,
-      simpleDate
+      {
+        date: dateonly
+      }
     )
     core.info(`Updated item: ${item.id} (${title})`)
   }

--- a/scripts/src/actions/shared/update-status-history.ts
+++ b/scripts/src/actions/shared/update-status-history.ts
@@ -41,7 +41,7 @@ export async function updateStatusHistory(
 ) {
   const date = new Date()
   const datetime = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()} ${date.getUTCHours()}:${date.getUTCMinutes()}`
-  const dateonly = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`
+  const dateonly = `${date.getUTCFullYear()}-${('0' + date.getUTCMonth()).slice(-2)}-${('0' + date.getUTCDate()).slice(-2)}`
   const github = await GitHub.getGitHub()
 
   core.info(`Searching for project: ${org}/${projectNumber}`)

--- a/scripts/src/actions/shared/update-status-history.ts
+++ b/scripts/src/actions/shared/update-status-history.ts
@@ -132,11 +132,11 @@ export async function updateStatusHistory(
     }
     core.debug(`Checking if item needs to be updated: ${item.id}`)
     const status = item.fieldValues.nodes.find(
-      (fieldValue: any) => fieldValue.field.id === statusField.id
+      (fieldValue: any) => fieldValue.field?.id === statusField.id
     )?.name
     const statusHistory = JSON.parse(
       item.fieldValues.nodes.find(
-        (fieldValue: any) => fieldValue.field.id === statusHistoryField.id
+        (fieldValue: any) => fieldValue.field?.id === statusHistoryField.id
       )?.text || '[]'
     )
     if (status === statusHistory.at(0)) {

--- a/scripts/src/actions/shared/update-status-history.ts
+++ b/scripts/src/actions/shared/update-status-history.ts
@@ -156,7 +156,7 @@ export async function updateStatusHistory(
       continue
     }
     core.info(`Updating item: ${item.id} (${title})`)
-    const newStatusHistory = [status.value, ...statusHistory.slice(0, 1)]
+    const newStatusHistory = [status, ...statusHistory.slice(0, 1)]
     await updateProjectV2ItemFieldValue(
       project.id,
       item.id,


### PR DESCRIPTION
We start using a ts script instead of https://github.com/pl-strflt/projects-status-history because the latter uses deprecated graphql APIs. 